### PR TITLE
Add VectorArray

### DIFF
--- a/src/nias-cpp/gram_schmidt.h
+++ b/src/nias-cpp/gram_schmidt.h
@@ -48,6 +48,39 @@ std::vector<V> gram_schmidt(const std::vector<V>& vecs, const std::string python
     return ret;
 }
 
+template <NiasVector V>
+std::vector<V> gram_schmidt(const VectorArray<V>& vec_array, const std::string python_name)
+{
+    namespace py = pybind11;
+    py::module_ nias_bindings = py::module::import("nias.bindings.nias_cpp.nias_cpp");
+    py::module_ nias_interfaces = py::module::import("nias.bindings.nias_cpp.interfaces");
+
+    // get the classes we need from the Python nias module
+    auto NiasVecArrayImpl = nias_interfaces.attr("NiasCppVectorArrayImpl");
+    auto NiasVecArray = nias_interfaces.attr("NiasCppVectorArray");
+    auto NiasCppInnerProduct = nias_bindings.attr("NiasCppInnerProduct");
+    auto NiasGramSchmidt = py::module::import("nias.linalg.gram_schmidt").attr("gram_schmidt");
+
+    using namespace pybind11::literals;
+
+    // create space and and a vectorarray containing vecs
+    auto nias_vec_array = NiasVecArray("impl"_a = NiasVecArrayImpl(vec_array));
+
+    // execute the Python gram_schmidt function
+    py::object result = NiasGramSchmidt(nias_vec_array, NiasCppInnerProduct(), "copy"_a = false);
+
+    // convert result back to C++ vectors
+    auto py_result = result.attr("vectors");
+    std::vector<V> ret;
+    for (auto& py_vec : py_result)
+    {
+        // ret.emplace_back(py::cast<V>(py_vec.attr("impl")));
+        ret.emplace_back(py::cast<V>(py_vec));
+    }
+
+    return ret;
+}
+
 
 }  // namespace nias
 

--- a/src/nias-cpp/gram_schmidt.h
+++ b/src/nias-cpp/gram_schmidt.h
@@ -1,6 +1,7 @@
 #ifndef NIAS_CPP_GRAM_SCHMIDT_H
 #define NIAS_CPP_GRAM_SCHMIDT_H
 
+#include <functional>
 #include <vector>
 
 #include <nias-cpp/vector.h>
@@ -10,32 +11,33 @@ namespace nias
 {
 
 
+// python_name is the name under which V is exposed (via pybind11 bindings) on the Python side
 template <NiasVector V>
 std::vector<V> gram_schmidt(const std::vector<V>& vecs, const std::string python_name)
 {
-    namespace py = pybind11;
-    py::module_ nias_bindings = py::module::import("nias.bindings.nias_cpp.nias_cpp");
-
     // get the classes we need from the Python nias module
-    auto NiasCppVector = nias_bindings.attr("NiasCppVector");
-    auto NiasCppListVectorSpace = nias_bindings.attr("NiasCppListVectorSpace");
-    auto NiasCppInnerProduct = nias_bindings.attr("NiasCppInnerProduct");
+    namespace py = pybind11;
+    py::module_ nias_cpp_vector = py::module::import("nias.bindings.nias_cpp.vector");
+    auto NiasCppVector = nias_cpp_vector.attr("NiasCppVector");
+    auto NiasCppListVectorSpace = nias_cpp_vector.attr("NiasCppListVectorSpace");
+    auto NiasCppInnerProduct =
+        py::module::import("nias.bindings.nias_cpp.product").attr("NiasCppInnerProduct");
     auto NiasGramSchmidt = py::module::import("nias.linalg.gram_schmidt").attr("gram_schmidt");
 
     // create space and and a vectorarray containing vecs
     assert(!vecs.empty());
-    auto dim = vecs[0].size();
+    const auto dim = vecs[0].size();
     auto space = NiasCppListVectorSpace(dim, python_name);
     py::list py_vecs;
     for (const auto& vec : vecs)
     {
-        py_vecs.append(space.attr("make_vector")(vec));
+        py_vecs.append(space.attr("make_vector")(std::cref(vec)));
     }
     auto nias_vec_array = space.attr("from_vectors")(py_vecs);
 
     // execute the Python gram_schmidt function
     using namespace pybind11::literals;
-    py::object result = NiasGramSchmidt(nias_vec_array, NiasCppInnerProduct(), "copy"_a = false);
+    py::object result = NiasGramSchmidt(nias_vec_array, NiasCppInnerProduct(), "copy"_a = true);
 
     // convert result back to C++ vectors
     auto py_result = result.attr("vectors");
@@ -49,36 +51,48 @@ std::vector<V> gram_schmidt(const std::vector<V>& vecs, const std::string python
 }
 
 template <NiasVector V>
-std::vector<V> gram_schmidt(const VectorArray<V>& vec_array, const std::string python_name)
+VectorArray<V> gram_schmidt(const VectorArray<V>& vec_array)
 {
-    namespace py = pybind11;
-    py::module_ nias_bindings = py::module::import("nias.bindings.nias_cpp.nias_cpp");
-    py::module_ nias_interfaces = py::module::import("nias.bindings.nias_cpp.interfaces");
-
     // get the classes we need from the Python nias module
-    auto NiasVecArrayImpl = nias_interfaces.attr("NiasCppVectorArrayImpl");
-    auto NiasVecArray = nias_interfaces.attr("NiasCppVectorArray");
-    auto NiasCppInnerProduct = nias_bindings.attr("NiasCppInnerProduct");
+    namespace py = pybind11;
+    py::module_ nias_cpp_vectorarray = py::module::import("nias.bindings.nias_cpp.vectorarray");
+    auto NiasVecArrayImpl = nias_cpp_vectorarray.attr("NiasCppVectorArrayImpl");
+    auto NiasVecArray = nias_cpp_vectorarray.attr("NiasCppVectorArray");
+    auto NiasCppInnerProduct =
+        py::module::import("nias.bindings.nias_cpp.product").attr("NiasCppInnerProduct");
     auto NiasGramSchmidt = py::module::import("nias.linalg.gram_schmidt").attr("gram_schmidt");
 
-    using namespace pybind11::literals;
-
-    // create space and and a vectorarray containing vecs
-    auto nias_vec_array = NiasVecArray("impl"_a = NiasVecArrayImpl(vec_array));
+    // create a Python VectorArray
+    using namespace pybind11::literals;  // for the _a literal
+    auto nias_vec_array = NiasVecArray("impl"_a = NiasVecArrayImpl(std::cref(vec_array)));
 
     // execute the Python gram_schmidt function
-    py::object result = NiasGramSchmidt(nias_vec_array, NiasCppInnerProduct(), "copy"_a = false);
+    py::object result = NiasGramSchmidt(nias_vec_array, NiasCppInnerProduct(), "copy"_a = true);
 
-    // convert result back to C++ vectors
-    auto py_result = result.attr("vectors");
-    std::vector<V> ret;
-    for (auto& py_vec : py_result)
-    {
-        // ret.emplace_back(py::cast<V>(py_vec.attr("impl")));
-        ret.emplace_back(py::cast<V>(py_vec));
-    }
+    // We could also just do
+    // return result.attr("impl").attr("impl").cast<VectorArray<V>>();
+    // but that would copy the VectorArray instead of moving it
+    return std::move(*result.attr("impl").attr("impl").cast<VectorArray<V>*>());
+}
 
-    return ret;
+template <NiasVector V>
+void gram_schmidt_in_place(VectorArray<V>& vec_array)
+{
+    // get the classes we need from the Python nias module
+    namespace py = pybind11;
+    py::module_ nias_cpp_vectorarray = py::module::import("nias.bindings.nias_cpp.vectorarray");
+    auto NiasVecArrayImpl = nias_cpp_vectorarray.attr("NiasCppVectorArrayImpl");
+    auto NiasVecArray = nias_cpp_vectorarray.attr("NiasCppVectorArray");
+    auto NiasCppInnerProduct =
+        py::module::import("nias.bindings.nias_cpp.product").attr("NiasCppInnerProduct");
+    auto NiasGramSchmidt = py::module::import("nias.linalg.gram_schmidt").attr("gram_schmidt");
+
+    // create a Python VectorArray
+    using namespace pybind11::literals;  // for the _a literal
+    auto nias_vec_array = NiasVecArray("impl"_a = NiasVecArrayImpl(std::ref(vec_array)));
+
+    // execute the Python gram_schmidt function
+    NiasGramSchmidt(nias_vec_array, NiasCppInnerProduct(), "copy"_a = false);
 }
 
 

--- a/src/nias-cpp/vector.h
+++ b/src/nias-cpp/vector.h
@@ -1,10 +1,14 @@
 #ifndef NIAS_CPP_VECTOR_H
 #define NIAS_CPP_VECTOR_H
 
+#include <algorithm>
 #include <concepts>
+#include <iostream>
+#include <set>
 #include <vector>
 
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 namespace nias
 {
@@ -13,11 +17,240 @@ namespace nias
 // C++20 concept for a vector of doubles which has copy, dot, scal, and axpy methods
 template <class V>
 concept NiasVector = requires(V v) {
+    // TODO: update requirements
     { v.size() } -> std::convertible_to<std::size_t>;
     { v.copy() } -> std::same_as<V>;
     { v.dot(v) } -> std::convertible_to<double>;
     { v.scal(1.0) };
     { v.axpy(1.0, v) };
+};
+
+template <NiasVector VectorType>
+class VectorArray
+{
+   public:
+    VectorArray(const std::vector<VectorType>& vectors, size_t dim)
+        : vectors_(std::move(vectors))
+        , dim_(dim)
+    {
+        check_vec_dimensions();
+    }
+
+    VectorArray(std::vector<VectorType>&& vectors, size_t dim)
+        : vectors_(std::move(vectors))
+        , dim_(dim)
+    {
+        check_vec_dimensions();
+    }
+
+    size_t size() const
+    {
+        return vectors_.size();
+    }
+
+    size_t dim() const
+    {
+        return dim_;
+    }
+
+    const std::vector<VectorType>& vectors() const
+    {
+        return vectors_;
+    }
+
+    bool is_compatible_array(const VectorArray& other) const
+    {
+        return dim_ == other.dim_;
+    }
+
+    VectorArray copy(const std::vector<size_t>& indices = {}) const
+    {
+        if (indices.empty())
+        {
+            return VectorArray(vectors_, dim_);
+        }
+        else
+        {
+            std::vector<VectorType> copied_vectors;
+            copied_vectors.reserve(indices.size());
+            std::ranges::transform(indices, std::back_inserter(copied_vectors),
+                                   [this](size_t i)
+                                   {
+                                       return vectors_.at(i);
+                                   });
+            return VectorArray(copied_vectors, dim_);
+        }
+    }
+
+    void append(VectorArray& other, bool remove_from_other = false,
+                const std::vector<size_t>& other_indices = {})
+    {
+        if (!is_compatible_array(other))
+        {
+            throw std::invalid_argument("VectorArray: incompatible dimensions.");
+        }
+        vectors_.reserve(vectors_.size() + other_indices.size());
+        if (remove_from_other)
+        {
+            append_with_removal(other, other_indices);
+        }
+        else
+        {
+            append_without_removal(other, other_indices);
+        }
+    }
+
+    void delete_vectors(const std::vector<size_t>& indices)
+    {
+        // We first sort and deduplicate indices by converting to a std::set
+        // We sort in reverse order (by using std::greater as second template argument) to avoid
+        // invalidating indices when removing elements from the vector
+        std::set<size_t, std::greater<size_t>> sorted_indices(indices.begin(), indices.end());
+        for (auto&& i : sorted_indices)
+        {
+            vectors_.erase(vectors_.begin() + i);
+        }
+    }
+
+    void scal(const double& alpha, const std::vector<size_t>& indices = {})
+    {
+        if (indices.empty())
+        {
+            for (auto& vector : vectors_)
+            {
+                vector.scal(alpha);
+            }
+        }
+        else
+        {
+            for (auto i : indices)
+            {
+                vectors_.at(i).scal(alpha);
+            }
+        }
+    }
+
+    void scal(const std::vector<double>& alpha, const std::vector<size_t>& indices = {})
+    {
+        if (indices.empty())
+        {
+            if (alpha.size() != size())
+            {
+                throw std::invalid_argument(
+                    "VectorArray: alpha must be scalar or have the same length as the array.");
+            }
+            for (size_t i = 0; i < vectors_.size(); ++i)
+            {
+                vectors_.at(i).scal(alpha.at(i));
+            }
+        }
+        else
+        {
+            if (alpha.size() != indices.size())
+            {
+                throw std::invalid_argument("VectorArray: number of scalars must match number of indices.");
+            }
+            for (size_t i = 0; i < indices.size(); ++i)
+            {
+                vectors_.at(indices.at(i)).scal(alpha.at(i));
+            }
+        }
+    }
+
+    void axpy(const std::vector<double>& alpha, const VectorArray& x, const std::vector<size_t>& indices = {},
+              const std::vector<size_t>& x_indices = {})
+    {
+        if (!is_compatible_array(x))
+        {
+            throw std::invalid_argument("VectorArray: incompatible dimensions.");
+        }
+        const auto this_size = indices.empty() ? size() : indices.size();
+        const auto x_size = x_indices.empty() ? x.size() : x_indices.size();
+        if (!(this_size == x_size || x_size == 1))
+        {
+            throw std::invalid_argument("VectorArray: x must have length 1 or the same length as this");
+        }
+        if (!(alpha.size() == x_size || alpha.size() == 1))
+        {
+            throw std::invalid_argument("VectorArray: alpha must be a scalar or have the same length as x");
+        }
+
+        for (size_t i = 0; i < this_size; ++i)
+        {
+            const auto this_index = indices.empty() ? i : indices.at(i);
+            // x can either have the same length as this or length 1
+            size_t x_index;
+            if (x_size == this_size)
+            {
+                x_index = x_indices.empty() ? i : x_indices.at(i);
+            }
+            else
+            {
+                // x has length 1
+                x_index = x_indices.empty() ? 0 : x_indices.at(0);
+            }
+            const auto a = alpha.size() == 1 ? alpha.at(0) : alpha.at(x_index);
+            vectors_.at(this_index).axpy(a, x.vectors_.at(x_index));
+        }
+    }
+
+    void axpy(double alpha, const VectorArray& x, const std::vector<size_t>& indices = {},
+              const std::vector<size_t>& x_indices = {})
+    {
+        axpy(std::vector<double> {alpha}, x, indices, x_indices);
+    }
+
+   private:
+    void check_vec_dimensions()
+    {
+        for (const auto& vector : vectors_)
+        {
+            if (vector.size() != dim_)
+            {
+                throw std::invalid_argument("VectorArray: all vectors must have the same length.");
+            }
+        }
+    }
+
+    void append_without_removal(const VectorArray& other, std::vector<size_t> other_indices = {})
+    {
+        if (other_indices.empty())
+        {
+            vectors_.insert(vectors_.end(), other.vectors_.begin(), other.vectors_.end());
+        }
+        else
+        {
+            std::ranges::transform(other_indices, std::back_inserter(vectors_),
+                                   [&other](size_t i)
+                                   {
+                                       return other.vectors_[i];
+                                   });
+        }
+    }
+
+    void append_with_removal(VectorArray& other, const std::vector<size_t>& other_indices)
+    {
+        if (other_indices.empty())
+        {
+            // move all vectors from other to this and then clear other
+            vectors_.insert(vectors_.end(), std::make_move_iterator(other.vectors_.begin()),
+                            std::make_move_iterator(other.vectors_.end()));
+            other.vectors_.clear();
+        }
+        else
+        {
+            // move selected entries of other to the end of this
+            std::ranges::transform(other_indices, std::back_inserter(vectors_),
+                                   [&other](size_t i)
+                                   {
+                                       return std::move(other.vectors_[i]);
+                                   });
+            other.delete_vectors(other_indices);
+        }
+    }
+
+    std::vector<VectorType> vectors_;
+    size_t dim_;
 };
 
 template <NiasVector V>
@@ -34,6 +267,36 @@ auto bind_nias_vector(pybind11::module& m, const std::string name)
                    .def("dot", &V::dot)
                    .def("scal", &V::scal)
                    .def("axpy", &V::axpy);
+    return ret;
+}
+
+template <NiasVector V>
+auto bind_nias_vectorarray(pybind11::module& m, const std::string name)
+{
+    namespace py = pybind11;
+    using VecArray = VectorArray<V>;
+    auto ret =
+        py::class_<VecArray>(m, name.c_str())
+            .def("__len__",
+                 [](const VecArray& v)
+                 {
+                     return v.size();
+                 })
+            .def("size", &VecArray::size)
+            .def_property_readonly("dim", &VecArray::dim)
+            .def_property_readonly("vectors", &VecArray::vectors)
+            .def("copy", &VecArray::copy)
+            .def("append", &VecArray::append)
+            .def("delete", &VecArray::delete_vectors)
+            .def("scal", py::overload_cast<const double&, const std::vector<size_t>&>(&VecArray::scal))
+            .def("scal",
+                 py::overload_cast<const std::vector<double>&, const std::vector<size_t>&>(&VecArray::scal))
+            .def("axpy", py::overload_cast<double, const VecArray&, const std::vector<size_t>&,
+                                           const std::vector<size_t>&>(&VecArray::axpy))
+            .def("axpy",
+                 py::overload_cast<const std::vector<double>&, const VecArray&, const std::vector<size_t>&,
+                                   const std::vector<size_t>&>(&VecArray::axpy))
+            .def("is_compatible_array", &VecArray::is_compatible_array);
     return ret;
 }
 

--- a/tests/gram_schmidt_test.cpp
+++ b/tests/gram_schmidt_test.cpp
@@ -43,6 +43,8 @@ int main()
     std::vector<ExampleVector> vectors {{1., 2., 3.}, {4., 5., 6.}, {7., 8., 9.}};
     print(vectors, "Input");
 
+    VectorArray<ExampleVector> vec_array(vectors, 3);
+
     // Start the interpreter and import the test module
     py::scoped_interpreter guard {};  // start the interpreter and keep it alive
     py::module_ nias_cpp_test_module = py::module::import("nias_cpp_test");
@@ -50,8 +52,10 @@ int main()
     // Perform Gram-Schmidt orthogonalization and print result
     std::cout << "\n\nPerforming Gram-Schmidt orthogonalization... ";
     auto orthonormalized_vectors = nias::gram_schmidt(vectors, "ExampleVector");
+    auto orthonormalized_vectors_2 = nias::gram_schmidt(vec_array, "ExampleVector");
     std::cout << "done!\n\n" << std::endl;
-    print(orthonormalized_vectors, "Output");
+    print(orthonormalized_vectors, "Output Vectors");
+    print(orthonormalized_vectors_2, "Output VecArray");
 
     return 0;
 }

--- a/tests/gram_schmidt_test.cpp
+++ b/tests/gram_schmidt_test.cpp
@@ -52,10 +52,12 @@ int main()
     // Perform Gram-Schmidt orthogonalization and print result
     std::cout << "\n\nPerforming Gram-Schmidt orthogonalization... ";
     auto orthonormalized_vectors = nias::gram_schmidt(vectors, "ExampleVector");
-    auto orthonormalized_vectors_2 = nias::gram_schmidt(vec_array, "ExampleVector");
+    auto orthonormalized_vectorarray = nias::gram_schmidt(vec_array);
+    nias::gram_schmidt_in_place(vec_array);
     std::cout << "done!\n\n" << std::endl;
     print(orthonormalized_vectors, "Output Vectors");
-    print(orthonormalized_vectors_2, "Output VecArray");
+    print(orthonormalized_vectorarray.vectors(), "Output VecArray");
+    print(vec_array.vectors(), "Output VecArray in-place");
 
     return 0;
 }

--- a/tests/test_module.cpp
+++ b/tests/test_module.cpp
@@ -20,6 +20,19 @@ ExampleVector::ExampleVector(const ExampleVector& other)
 ExampleVector::ExampleVector(ExampleVector&& other)
     : data_(std::move(other.data_)) {};
 
+// ExampleVector copy and move assignment operators
+ExampleVector& ExampleVector::operator=(const ExampleVector& other)
+{
+    data_ = other.data_;
+    return *this;
+}
+
+ExampleVector& ExampleVector::operator=(ExampleVector&& other)
+{
+    data_ = std::move(other.data_);
+    return *this;
+}
+
 // ExampleVector iterators
 ExampleVector::Iterator ExampleVector::begin()
 {
@@ -79,4 +92,5 @@ PYBIND11_MODULE(nias_cpp_test, m)
 {
     m.doc() = "nias-cpp test bindings";  // optional module docstring
     nias::bind_nias_vector<ExampleVector>(m, "ExampleVector");
+    nias::bind_nias_vectorarray<ExampleVector>(m, "ExampleVectorArray");
 }

--- a/tests/test_module.h
+++ b/tests/test_module.h
@@ -18,6 +18,10 @@ class ExampleVector
     ExampleVector(const ExampleVector& other);
     ExampleVector(ExampleVector&& other);
 
+    // copy and move assignment operators
+    ExampleVector& operator=(const ExampleVector& other);
+    ExampleVector& operator=(ExampleVector&& other);
+
     // iterators
     Iterator begin();
     Iterator end();


### PR DESCRIPTION
This PR adds a C++ VectorArray implementation and uses it to call the Python `gram_schmidt` algorithm. The in-place variant does not do any copies.

Based on #2.

Needs the NiAS adaptions from https://github.com/nias-project/nias/pull/32.