### PR TITLE
Add tests to ci

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,0 +1,145 @@
+---
+# This file is part of the NiAS project (https://github.com/nias-project).
+# Copyright NiAS developers and contributors. All rights reserved.
+# License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
+name: Build and Test
+
+# merge_group triggers happen in merge queues
+# workflow_dispatch triggers happen when a user manually runs the workflow
+# pull_request triggers happen when a pull request is updated
+on:
+  pull_request:
+    # defaults + "ready_for_review" (so full matrix is run when that's toggled)
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: build_and_test_${{ github.event.ref }}
+  cancel-in-progress: true
+
+jobs:
+  determine_jobs:
+    name: Determine which jobs to run
+    runs-on: ubuntu-24.04
+    timeout-minutes: 2
+    outputs:
+      ubuntu_matrix: ${{ steps.determine_build_and_test_jobs.outputs.ubuntu_matrix }}
+      windows_matrix: ${{ steps.determine_build_and_test_jobs.outputs.windows_matrix }}
+    steps:
+
+    - name: Determine build and test jobs (draft=${{github.event.pull_request.draft}})
+      id: determine_build_and_test_jobs
+      shell: python {0}
+      env:
+        IS_DRAFT: ${{ github.event.pull_request.draft }}
+      run: |
+        import os
+        from pathlib import Path
+        import json
+
+        ubuntu_types = ['Debug']
+        windows_types = []
+
+        draft = os.getenv('IS_DRAFT') == 'true'
+        if not draft:
+          ubuntu_types += ['Release']
+          windows_types += ['Debug', 'Release']
+
+        ubuntu_types = json.dumps({'include': [{'type': type} for type in ubuntu_types]})
+        windows_types = json.dumps({'include': [{'type': type} for type in windows_types]})
+
+        with Path(os.environ['GITHUB_OUTPUT']).open('wt') as f:
+          f.write(f"ubuntu_matrix={ubuntu_types}\n")
+          f.write(f"windows_matrix={windows_types}\n")
+
+  build_and_test_ubuntu:
+    needs: determine_jobs
+    strategy:
+      matrix: ${{ fromJson(needs.determine_jobs.outputs.ubuntu_matrix) }}
+      fail-fast: false
+    name: Build and Test (Ubuntu/${{ matrix.type }})
+    runs-on: ubuntu-24.04
+    defaults:
+      run:
+        shell: bash -elo pipefail {0}
+    timeout-minutes: 15
+    steps:
+
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Setup uv
+      uses: yezz123/setup-uv@v4
+
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Configure with cmake
+      run: |
+        cmake -B build -DPython_EXECUTABLE="$(which python3.12)" -DCMAKE_BUILD_TYPE=${{ matrix.type }}
+
+    - name: Build with cmake
+      run: |
+        cmake --build build
+
+    - name: Build C++ tests with cmake
+      run: |
+        cmake --build build --target all_test_binaries
+
+    - name: Run C++ tests with ctest
+      id: run_tests
+      run: |
+        ctest --test-dir build
+
+    - name: Re-run failed tests for more information
+      if: always() && steps.run_tests.conclusion == 'failure'
+      run: |
+        ctest --test-dir build --rerun-failed --output-on-failure
+
+
+  build_and_test_windows:
+    needs: determine_jobs
+    strategy:
+      matrix: ${{ fromJson(needs.determine_jobs.outputs.ubuntu_matrix) }}
+      fail-fast: false
+    name: Build and Test (Windows/${{ matrix.type }})
+    runs-on: windows-2022
+    defaults:
+      run:
+        shell: bash -elo pipefail {0}
+    timeout-minutes: 15
+    steps:
+
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Setup uv
+      uses: yezz123/setup-uv@v4
+
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Configure with cmake
+      run: |
+        cmake -B build -DPython_EXECUTABLE="$(which python3.12)" -DCMAKE_BUILD_TYPE=${{ matrix.type }}
+
+    - name: Build with cmake
+      run: |
+        cmake --build build --config ${{ matrix.type }}
+
+    - name: Build C++ tests with cmake
+      run: |
+        cmake --build build --config ${{ matrix.type }} --target all_test_binaries
+
+    - name: Run C++ tests with ctest
+      id: run_tests
+      run: |
+        ctest --test-dir build -C ${{ matrix.type }}
+
+    - name: Re-run failed tests for more information
+      if: always() && steps.run_tests.conclusion == 'failure'
+      run: |
+        ctest --test-dir build -C ${{ matrix.type }} --rerun-failed --output-on-failure

--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,4 @@ docs/source/_static/standalone.js*
 
 # uv
 uv.lock
+Testing

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ find_package(nias_cpp PATHS ${CMAKE_CURRENT_SOURCE_DIR}/cmake NO_DEFAULT_PATH)
 
 # add tests if this is the master project
 if(NIAS_CPP_MASTER_PROJECT)
+    include(CTest)
     include(FetchContent)
     # add boost-ext/ut testing framework
     FetchContent_Declare(

--- a/README.md
+++ b/README.md
@@ -1,46 +1,56 @@
-# C++ bindings for NIAS - Numerics In Abstract Spaces
+# C++ bindings for NiAS - Numerics In Abstract Spaces
 
-This library provides C++ bindings for [NiAS](https://github.com/nias-project/nias) which is a Python library
-providing numerical algorithms (e.g., Gram-Schmidt orthonormalization) formulated in the context of abstract
-(mathematical) spaces.
+This library provides C++ bindings for [NiAS](https://github.com/nias-project/nias).
+
+NiAS-C++ can be seen as (modern cmake)-based C++ project with Python bindings and at the sime time
+as a [scikit-build-core](https://github.com/scikit-build/scikit-build-core)-based Python project with C extensions.
 
 ## Quick Start
 
-To run the Gram-Schmidt test (which creates a few vectors and orthogonalizes them using NiAS's Gram-Schmidt algorithm)
-you can use the following commands:
+### C++ development
 
-```bash
-python3 -m venv venv
-source venv/bin/activate
-pip install .
-mkdir build && cd build
-cmake ..
-make
-./tests/test_gram_schmidt
-```
+To work on the NiAS-C++ as a C++ project, you will need git, cmake, ninja and a recent C++ compiler.
 
-Alternatively, you can use `uv` for the first steps
+1. Clone the repository and (optionally) check out a branch:
 
-```bash
-uv venv
-uv pip install .
-source .venv/bin/activate
-```
+   ```bash
+   git clone https://github.com/nias-project/nias-cpp.git
+   cd nias-cgg
+   git checkout <some branch>  # optional
+   ```
 
-Additional compiler flags can be added as usual, e.g., you can use
+2. Configure the project with cmake:
 
-```bash
-cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -Wall -Wextra ..
-```
+   ```bash
+   cmake -B build -DPython_EXECUTABLE=$(which python3)
+   ```
 
-to use ninja instead of make and build with debugging information and additional warnings.
+   This will download [uv](https://docs.astral.sh/uv/) and all dependencies
+   (taking [pyproject.toml](pyproject.toml) into account),
+   and configure a release build by default.
+   Passing `-DCMAKE_BUILD_TYPE=Debug` or other cmake options works as usual.
 
-To run the python test, copy the test over to the build directory and run it with the python interpreter:
+3. Build the project with cmake:
 
-```bash
-cp ../tests/test_gram_schmidt.py .
-python3 test_gram_schmidt.py
-```
+   ```bash
+   cmake --build build
+   ```
+
+   This will also create and fill a Python virtualenv.
+
+4. Build the tests with cmake:
+
+   ```bash
+   cmake --build build --target all_test_binaries
+   ```
+
+   This will also copy shared libraries we depend upon into the test folder to allow executing the tests on all platforms.
+
+5. Run the suite of C++ tests with ctest:
+
+   ```bash
+   ctest --test-dir build
+   ```
 
 ## Current Status
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This library provides C++ bindings for [NiAS](https://github.com/nias-project/nias).
 
-NiAS-C++ can be seen as (modern cmake)-based C++ project with Python bindings and at the sime time
+NiAS-C++ can be seen as (modern cmake)-based C++ project with Python bindings and at the same time
 as a [scikit-build-core](https://github.com/scikit-build/scikit-build-core)-based Python project with C extensions.
 
 ## Quick Start
@@ -10,12 +10,14 @@ as a [scikit-build-core](https://github.com/scikit-build/scikit-build-core)-base
 ### C++ development
 
 To work on the NiAS-C++ as a C++ project, you will need git, cmake, ninja and a recent C++ compiler.
+Our [Build and Test workflow](.github/workflows/build_and_test_yml) give examples how to build and run
+on various platforms. The basic steps are as follows.
 
 1. Clone the repository and (optionally) check out a branch:
 
    ```bash
    git clone https://github.com/nias-project/nias-cpp.git
-   cd nias-cgg
+   cd nias-cpp
    git checkout <some branch>  # optional
    ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ authors = [
 ]
 dependencies = [
   "pybind11==2.13.6",
-  "nias@git+https://github.com/nias-project/nias@add_cpp_vectorarray"
+  "nias@git+https://github.com/nias-project/nias@188b58da859ff1cda55c14afd9c960b5d301ba34"
 ]
 
 [tool.scikit-build]

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,12 +1,20 @@
-set(TEST_EXECUTABLES gram_schmidt.cpp vectorarray/numpy.cpp vectorarray/list.cpp)
+set(ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+file(
+    GLOB_RECURSE test_sources
+    LIST_DIRECTORIES false
+    RELATIVE "${ROOT_DIR}"
+    "${ROOT_DIR}/*.cpp")
 
-foreach(test_executable IN LISTS TEST_EXECUTABLES)
+add_custom_target(all_test_binaries)
+
+foreach(test_executable ${test_sources})
     cmake_path(REMOVE_EXTENSION test_executable OUTPUT_VARIABLE _test_target)
     string(MAKE_C_IDENTIFIER ${_test_target} _test_target)
     set(_test_target test_${_test_target})
-    add_executable(${_test_target} ${test_executable})
+    add_executable(${_test_target} EXCLUDE_FROM_ALL ${test_executable})
     target_link_libraries(${_test_target} PRIVATE nias_cpp Boost::ut ${Python_LIBRARIES})
-    get_target_property(linked_libraries ${_test_target} LINK_LIBRARIES)
+    add_dependencies(all_test_binaries ${_test_target})
+    add_test(NAME ${_test_target} COMMAND ${_test_target})
 
     # copy python shared libraries to test directory
     # for some reason, the Python_LIBRARIES variable only contains the static libraries, so we
@@ -15,6 +23,7 @@ foreach(test_executable IN LISTS TEST_EXECUTABLES)
     file(GLOB shared_python_libs "${Python_RUNTIME_LIBRARY_DIRS}/*.so" "${Python_RUNTIME_LIBRARY_DIRS}/*.dll")
     set(_library_files ${shared_python_libs})
 
+    get_target_property(linked_libraries ${_test_target} LINK_LIBRARIES)
     foreach(lib IN LISTS linked_libraries)
         if(TARGET ${lib})
             get_property(


### PR DESCRIPTION
This refactors the C++ tests to automatically discover tests and register them for use with ctest. It also adds a _Build and Test_ workflow to CI to include in required branch protection in the future.

CI includes Windows and Ubuntu runners, and Debug and Release build types.
We don't employ cmake presets (yet) or pick a toolchain, but simply default to what's picked up on Github runners:

- the Windows runners use [the MSVC 19](https://github.com/nias-project/nias-cpp/actions/runs/13516242110/job/37765398608?pr=15#step:5:14) toolchain

- the Ubuntu runners use [GCC 13](https://github.com/nias-project/nias-cpp/actions/runs/13516242110/job/37765397990?pr=15#step:5:12)

The choice of OSes and build types depends on the PR status (to save time and resources while still in draft mode):

- while a PR is still in draft draft mode, only debug on Ubuntu is enabled: https://github.com/nias-project/nias-cpp/actions/runs/13508690543?pr=15

- once switched to ready-for-review, all OSes and build types are enabled: https://github.com/nias-project/nias-cpp/actions/runs/13516242110

TODO:

- [ ] fix [test_gram_schmidt](https://github.com/nias-project/nias-cpp/actions/runs/13516242110/job/37765397990#step:8:29)
- [ ] fix tests [not running on Windows](https://github.com/nias-project/nias-cpp/actions/runs/13516242110/job/37765398608#step:8:14)